### PR TITLE
fix: make `@types/emscripten` a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "license": "BSD-2-Clause",
   "type": "commonjs",
   "devDependencies": {
-    "@types/emscripten": "^1.39.6",
     "@types/node": "^18.7.14",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
@@ -42,5 +41,8 @@
     "lint:types": "eslint dist --ext .ts",
     "lint:tests": "eslint tests --ext .js",
     "lint": "run-s lint:types lint:tests"
+  },
+  "peerDependencies": {
+    "@types/emscripten": "^1.39.6"
   }
 }


### PR DESCRIPTION
As explained [here](https://stackoverflow.com/questions/54926369/what-dependency-type-should-types-be-for-a-published-package) `@types/` packages should be a peerDependency if the type is part of what the consumer of the package should see. Otherwise the type is unresolved for downstream developers.
